### PR TITLE
Fix cache error when data is missing

### DIFF
--- a/fourinsight/engineroom/utils/datamanage.py
+++ b/fourinsight/engineroom/utils/datamanage.py
@@ -394,11 +394,8 @@ class BaseDataSource(ABC):
     @staticmethod
     def _slice(df, start, end):
         """Slice dataframe and exclude endpoint"""
-        if df.empty:
-            return df
-
         df = df.loc[start:end]
-        if df.index[-1] == end:
+        if not df.empty and (df.index[-1] == end):
             df = df.iloc[:-1]
         return df
 

--- a/tests/test_datamanage.py
+++ b/tests/test_datamanage.py
@@ -98,6 +98,7 @@ class Test_BaseDataSource:
     def test__slice_empty(self):
         source = BaseDataSourceForTesting(IntegerIndexConverter())
         df = pd.DataFrame(data={"a": []}, index=[])
+        df.index = df.index.astype(int)
 
         df_out = source._slice(df, 5, 10)
         pd.testing.assert_frame_equal(df, df_out)


### PR DESCRIPTION
## Bug
If there is no data for a whole cache_size, the slice operation will cause: `IndexError: index -1 is out of bounds for axis 0 with size 0`

## To reproduce: 
1. Find a timeseries which has some missing data
2. Create DrioDataSource with cache_size so that at least one of the chunks has no data at all.
3. Call get() on the source.

## Fix
Fixed this by checking if the dataframe is empty before slicing. If it is not, the slicing is done. If it is, then nothing is done and the empty df is added to the cache. This way, when you call with a data range containing a chunk of missing data, the result will be all the data available in that period, and not cause an error.
