### PR TITLE
docs: fix external links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,12 +89,12 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/4subsea/fourinsight-xyz",
+            "url": "https://github.com/4Subsea/fourinsight-engineroom-utils-python",
             "icon": "fab fa-github",
         },
         {
             "name": "PyPI",
-            "url": "https://pypi.org/project/fourinsight-xyz",
+            "url": "https://pypi.org/project/fourinsight-engineroom-utils/",
             "icon": "fas fa-box",
         },
     ],


### PR DESCRIPTION
# This PR is related to user story DST-XXX

## Description
Icon links to github and pypi did not have correct URLs, led to a 404. These two links have been updated in conf.py. 


## Checklist
- [x] All COS are met.
- [x] All integration tests pass (if applicable).
- [x] New functions, methods and classes are added to the documentation.
- [x] New functions, methods and classes are tested (hint: check coverage report).
