### PR TITLE
Fix iter_index.date_range function so that it returns n periods (was: returned n-1)

### DIFF
--- a/fourinsight/engineroom/utils/iter_index/_iter_index.py
+++ b/fourinsight/engineroom/utils/iter_index/_iter_index.py
@@ -34,6 +34,9 @@ def date_range(
     end : list
         Sequence of end values as `pandas.Timestamp`.
     """
+    if periods:
+        periods += 1
+
     start_end = pd.date_range(
         start=start, end=end, periods=periods, freq=freq, inclusive=inclusive, **kwargs
     )

--- a/tests/test_iter_index.py
+++ b/tests/test_iter_index.py
@@ -24,7 +24,7 @@ class Test_date_range:
             start=start, end=end, periods=periods
         )
 
-        date_range = pd.date_range(start=start, end=end, periods=periods)
+        date_range = pd.date_range(start=start, end=end, periods=periods + 1)
         start_expect, end_expect = date_range[:-1], date_range[1:]
 
         assert (start_out == start_expect).all()


### PR DESCRIPTION
# This PR is related to user story DST-201

## Description
Provide a short description about the work that has been done.

## Checklist
- [ ] All COS are met.
- [ ] All integration tests pass (if applicable).
- [ ] New functions, methods and classes are added to the documentation.
- [ ] New functions, methods and classes are tested (hint: check coverage report).
