### PR TITLE
Allow pulling of partial results

### DIFF
--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -483,7 +483,7 @@ class ResultCollector:
             raise ValueError("Index must be 'DatetimeIndex'.")
 
         if source_headers_complete:
-            self._dataframe = df_source
+            self._dataframe = df_source[self._headers.keys()]
         else:
             cols_in_source = self.dataframe.columns.intersection(df_source.columns)
             cols_not_in_source = self.dataframe.columns.difference(df_source.columns)
@@ -495,7 +495,7 @@ class ResultCollector:
                     ),
                 ],
                 axis=1,
-            )
+            )[self._headers.keys()]
 
     def push(self):
         """

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -461,12 +461,7 @@ class ResultCollector:
             self._handler, index_col=0, parse_dates=True, dtype=self._headers
         )
 
-        if set(df_source.columns) != set(self._headers.keys()):
-            source_headers_complete = False
-        else:
-            source_headers_complete = True
-
-        if strict and not source_headers_complete:
+        if strict and set(df_source.columns) != set(self._headers.keys()):
             raise ValueError("Header is not valid.")
 
         if (
@@ -482,15 +477,10 @@ class ResultCollector:
         ):
             raise ValueError("Index must be 'DatetimeIndex'.")
 
-        if source_headers_complete:
-            df_new = df_source[self._headers.keys()]
-        else:
-            cols_in_source = self.dataframe.columns.intersection(df_source.columns)
-            cols_not_in_source = self.dataframe.columns.difference(df_source.columns)
-            df_new = df_source[cols_in_source]
-            df_new[cols_not_in_source] = None
+        columns_missing = self.dataframe.columns.difference(df_source.columns)
+        df_source[columns_missing] = None
 
-        self._dataframe = df_new[self._headers.keys()].astype(self._headers)
+        self._dataframe = df_source[self._headers.keys()].astype(self._headers)
 
     def push(self):
         """

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -483,19 +483,14 @@ class ResultCollector:
             raise ValueError("Index must be 'DatetimeIndex'.")
 
         if source_headers_complete:
-            self._dataframe = df_source[self._headers.keys()]
+            df_new = df_source[self._headers.keys()]
         else:
             cols_in_source = self.dataframe.columns.intersection(df_source.columns)
             cols_not_in_source = self.dataframe.columns.difference(df_source.columns)
-            self._dataframe = pd.concat(
-                [
-                    df_source[cols_in_source],
-                    pd.DataFrame(columns=cols_not_in_source).astype(
-                        {key: self._headers[key] for key in cols_not_in_source}
-                    ),
-                ],
-                axis=1,
-            )[self._headers.keys()]
+            df_new = df_source[cols_in_source]
+            df_new[cols_not_in_source] = None
+
+        self._dataframe = df_new[self._headers.keys()].astype(self._headers)
 
     def push(self):
         """

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -479,14 +479,13 @@ class ResultCollector:
         if source_headers_complete:
             self._dataframe = df_source
         else:
-            cols_intersection = self.dataframe.columns.intersection(df_source.columns)
-            cols_difference = self.dataframe.columns.difference(df_source.columns)
-            headers_difference = {key: self._headers[key] for key in cols_difference}
+            cols_in_source = self.dataframe.columns.intersection(df_source.columns)
+            cols_not_in_source = self.dataframe.columns.difference(df_source.columns)
             self._dataframe = pd.concat(
                 [
-                    df_source[cols_intersection],
-                    pd.DataFrame(columns=headers_difference.keys()).astype(
-                        headers_difference
+                    df_source[cols_in_source],
+                    pd.DataFrame(columns=cols_not_in_source).astype(
+                        {key: self._headers[key] for key in cols_not_in_source}
                     ),
                 ],
                 axis=1,

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -444,6 +444,12 @@ class ResultCollector:
         ----------
         raise_on_missing : bool
             Raise exception if results can not be pulled from source.
+        strict : bool
+            Whether to be strict with respect to headers in the source or not. Setting
+            `strict=True` (default) will require that the source has the exact same
+            headers as the `ResultCollector`. Setting `strict=False` will allow pulling
+            of partial results (i.e., headers that does not have results in source,
+            will be populated with `None` values).
         """
 
         self._handler.pull(raise_on_missing=raise_on_missing)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -667,6 +667,35 @@ class Test_ResultCollector:
         with pytest.raises(FileNotFoundError):
             results.pull(raise_on_missing=True)
 
+    def test_pull_strict(self, tmp_path):
+        handler = LocalFileHandler(tmp_path / "results.csv")
+
+        headers_a = {"a": float, "b": str, "c": int}
+        results_a = ResultCollector(headers_a, handler=handler)
+        results_a.new_row()
+        results_a.collect(a=1.2, b="foo", c=3)
+        results_a.new_row()
+        results_a.collect(a=4.5, b="bar", c=6)
+        results_a.push()
+
+        headers_b = {"b": str, "c": int, "d": float}  # partially different headers
+        results_b = ResultCollector(headers_b, handler=handler)
+        results_b.pull(strict=False)
+
+        df_expect = pd.DataFrame(
+            data={
+                "b": ["foo", "bar"],
+                "c": [3, 6],
+                "d": [None, None],
+            },
+            index=pd.Index([0, 1], dtype="int64"),
+        ).astype({"b": "string", "c": "Int64", "d": "float64"})
+
+        # Remove `check_index_type=False` when issue with index type in `pull` is fixed
+        pd.testing.assert_frame_equal(
+            results_b._dataframe, df_expect, check_index_type=False
+        )
+
     def test_pull_strict_raises(self, tmp_path):
         handler = LocalFileHandler(tmp_path / "results.csv")
 
@@ -678,7 +707,7 @@ class Test_ResultCollector:
         results_a.collect(a=4.5, b="bar", c=6)
         results_a.push()
 
-        headers_b = {"b": str, "c": int, "d": float}   # different headers
+        headers_b = {"b": str, "c": int, "d": float}  # different headers
         results_b = ResultCollector(headers_b, handler=handler)
         with pytest.raises(ValueError):
             results_b.pull()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -667,6 +667,22 @@ class Test_ResultCollector:
         with pytest.raises(FileNotFoundError):
             results.pull(raise_on_missing=True)
 
+    def test_pull_strict_raises(self, tmp_path):
+        handler = LocalFileHandler(tmp_path / "results.csv")
+
+        headers_a = {"a": float, "b": str, "c": int}
+        results_a = ResultCollector(headers_a, handler=handler)
+        results_a.new_row()
+        results_a.collect(a=1.2, b="foo", c=3)
+        results_a.new_row()
+        results_a.collect(a=4.5, b="bar", c=6)
+        results_a.push()
+
+        headers_b = {"b": str, "c": int, "d": float}   # different headers
+        results_b = ResultCollector(headers_b, handler=handler)
+        with pytest.raises(ValueError):
+            results_b.pull()
+
     def test_push_auto(self, tmp_path):
         handler = LocalFileHandler(tmp_path / "results.csv")
         headers = {"a": float, "b": str, "c": float, "d": str}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,7 +287,6 @@ class Test_PersistentDict:
 
     def test__setitem_jsonencode(self, persistent_dict):
         with patch.object(persistent_dict, "_jsonencoder") as mock_jsonencoder:
-
             persistent_dict["a"] = 1
             mock_jsonencoder.assert_called_once_with(1)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -682,6 +682,8 @@ class Test_ResultCollector:
         results_b = ResultCollector(headers_b, handler=handler)
         results_b.pull(strict=False)
 
+        df_out = results_b.dataframe
+
         df_expect = pd.DataFrame(
             data={
                 "b": ["foo", "bar"],
@@ -692,9 +694,7 @@ class Test_ResultCollector:
         ).astype({"b": "string", "c": "Int64", "d": "float64"})
 
         # Remove `check_index_type=False` when issue with index type in `pull` is fixed
-        pd.testing.assert_frame_equal(
-            results_b._dataframe, df_expect, check_index_type=False
-        )
+        pd.testing.assert_frame_equal(df_out, df_expect, check_index_type=False)
 
     def test_pull_strict_raises(self, tmp_path):
         handler = LocalFileHandler(tmp_path / "results.csv")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -682,9 +682,22 @@ class Test_ResultCollector:
         results_b = ResultCollector(headers_b, handler=handler)
         results_b.pull(strict=False)
 
-        df_out = results_b.dataframe
+        results_b.push()
+        results_a.pull(strict=False)
 
-        df_expect = pd.DataFrame(
+        df_out_a = results_a.dataframe
+        df_out_b = results_b.dataframe
+
+        df_expect_a = pd.DataFrame(
+            data={
+                "a": [None, None],
+                "b": ["foo", "bar"],
+                "c": [3, 6],
+            },
+            index=pd.Index([0, 1], dtype="int64"),
+        ).astype({"a": "float64", "b": "string", "c": "Int64"})
+
+        df_expect_b = pd.DataFrame(
             data={
                 "b": ["foo", "bar"],
                 "c": [3, 6],
@@ -694,7 +707,8 @@ class Test_ResultCollector:
         ).astype({"b": "string", "c": "Int64", "d": "float64"})
 
         # Remove `check_index_type=False` when issue with index type in `pull` is fixed
-        pd.testing.assert_frame_equal(df_out, df_expect, check_index_type=False)
+        pd.testing.assert_frame_equal(df_out_a, df_expect_a, check_index_type=False)
+        pd.testing.assert_frame_equal(df_out_b, df_expect_b, check_index_type=False)
 
     def test_pull_strict_raises(self, tmp_path):
         handler = LocalFileHandler(tmp_path / "results.csv")


### PR DESCRIPTION
# This PR is related to user story DST-501

## Description
Allow pulling of partial results by setting `strict=False`.

## Checklist
- [x] All COS are met.
- [x] All integration tests pass (if applicable).
- [x] New functions, methods and classes are added to the documentation.
- [x] New functions, methods and classes are tested (hint: check coverage report).
