### PR TITLE
Bugfix on backward compatibility of pandas

### DIFF
--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -457,14 +457,21 @@ class ResultCollector:
             return
 
         self._handler.seek(0)
-        df_source = pd.read_csv(
-            self._handler,
-            index_col=0,
-            parse_dates=True,
-            dtype=self._headers,
-            date_format="ISO8601",
-        )
-
+        try:
+            df_source = pd.read_csv(
+                self._handler,
+                index_col=0,
+                parse_dates=True,
+                dtype=self._headers,
+                date_format="ISO8601",
+            )
+        except TypeError:  # for backward compatibility (remove after 2024-06-01)
+            df_source = pd.read_csv(
+                self._handler,
+                index_col=0,
+                parse_dates=True,
+                dtype=self._headers,
+            )
         if strict and set(df_source.columns) != set(self._headers.keys()):
             raise ValueError("Header is not valid.")
 


### PR DESCRIPTION
### This PR is related to user story [ESS-2347](https://4insight.atlassian.net/browse/ESS-2347)

## Description
`date_format` in `pd.read_csv` is functionality that is implemented in pandas 2. When using `pd.read_csv` without `date_format` you get a UserWarning. This is handled with a try/except statement. With time, when the program does not support pandas < 2, this should be deleted. 

The change is tested in [this](https://github.com/heidi-holm-4ss/track_4insight_usage) program where is where the problem was first found. 

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:

  


[ESS-2347]: https://4insight.atlassian.net/browse/ESS-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ