### PR TITLE
ESS-3423 3.11 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,4 +38,4 @@ jobs:
 
       - name: Test doc build with tox
         run: tox -e docs
-        if: ${{ (matrix.python-version == '3.11') && (matrix.os == 'ubuntu-latest')}}
+        if: ${{ (matrix.python-version == '3.12') && (matrix.os == 'ubuntu-latest')}}

--- a/.github/workflows/deploy_public.yml
+++ b/.github/workflows/deploy_public.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Head over to `Python.org`_ for instructions.
 
 Python version support
 ----------------------
-Officially Python 3.10, 3.11, and 3.12. We aim to support the three most
+Officially Python 3.11, 3.12, and 3.13. We aim to support the three most
 recent major versions.
 
 OS support

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -3,7 +3,7 @@
 Support
 =======
 For bug/issue reports, please submit an issue on `GitHub`_. For questions and feedback contact
-us at feedback@4insight.io
+us at support@4subsea.com
 
 .. _GitHub: https://github.com/4subsea/fourinsight-engineroom-utils-python
 

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -374,7 +374,10 @@ class ResultCollector:
         ).astype(self._headers)
 
         self._dataframe = pd.concat(
-            [self._dataframe, row_new],
+            [
+                self._dataframe if not self._dataframe.empty else None,
+                row_new if not row_new.empty else None,
+            ],
             verify_integrity=True,
             ignore_index=self._ignore_index,
             sort=False,

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -536,6 +536,8 @@ class ResultCollector:
         after : int or datetime-like, optional
             Delete results with index greater than this value.
         """
+        if self._dataframe.empty == True:
+            return
         index_drop = []
         if before:
             index_drop.extend(self._dataframe.index[(self._dataframe.index < before)])

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -536,7 +536,7 @@ class ResultCollector:
         after : int or datetime-like, optional
             Delete results with index greater than this value.
         """
-        if self._dataframe.empty == True:
+        if self._dataframe.empty:
             return
         index_drop = []
         if before:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,13 @@ url = https://4insight.io/
 classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 packages = find_namespace:
-python_requires = >=3.10
+python_requires = >=3.11
 install_requires =
     pandas
     azure-storage-blob >= 12.4.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -964,7 +964,6 @@ class Test_ResultCollector:
 
         pd.testing.assert_frame_equal(df_out, df_expect)
 
-
     def test_delete_rows_truncate_timestamp(self):
         headers = {"a": float, "b": str, "c": int, "d": float}
         results = ResultCollector(headers, indexing_mode="timestamp")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -947,6 +947,24 @@ class Test_ResultCollector:
 
         pd.testing.assert_frame_equal(df_out, df_expect)
 
+    def test_when_noe_rows_delete_rows_truncate_timestamp(self):
+        headers = {"a": float, "b": str, "c": int, "d": float}
+        results = ResultCollector(headers, indexing_mode="timestamp")
+        results.truncate(before="2020-01-01 01:00", after="2020-01-01 03:00")
+        df_out = results.dataframe
+        df_expect = pd.DataFrame(
+            data={
+            },
+            index=pd.DatetimeIndex(
+                [
+                ],
+                tz="utc",
+            ),
+        ).astype({"a": "float64", "b": "string", "c": "Int64", "d": "float64"})
+
+        pd.testing.assert_frame_equal(df_out, df_expect)
+
+
     def test_delete_rows_truncate_timestamp(self):
         headers = {"a": float, "b": str, "c": int, "d": float}
         results = ResultCollector(headers, indexing_mode="timestamp")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -952,12 +952,8 @@ class Test_ResultCollector:
         results = ResultCollector(headers, indexing_mode="timestamp")
         results.truncate(before="2020-01-01 01:00", after="2020-01-01 03:00")
         df_out = results.dataframe
-        df_expect = pd.DataFrame(
-            data={"a": [], "b": [], "c": [], "d": []},
-            index=pd.RangeIndex(start=0, stop=0, step=1),
-        ).astype({"a": "float", "b": "string", "c": "Int64", "d": "float"})
 
-        pd.testing.assert_frame_equal(df_out, df_expect)
+        assert df_out.empty
 
     def test_delete_rows_truncate_timestamp(self):
         headers = {"a": float, "b": str, "c": int, "d": float}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -953,12 +953,9 @@ class Test_ResultCollector:
         results.truncate(before="2020-01-01 01:00", after="2020-01-01 03:00")
         df_out = results.dataframe
         df_expect = pd.DataFrame(
-            data={},
-            index=pd.DatetimeIndex(
-                [],
-                tz="utc",
-            ),
-        ).astype({"a": "float64", "b": "string", "c": "Int64", "d": "float64"})
+            data={"a": [], "b": [], "c": [], "d": []},
+            index=pd.RangeIndex(start=0, stop=0, step=1),
+        ).astype({"a": "float", "b": "string", "c": "Int64", "d": "float"})
 
         pd.testing.assert_frame_equal(df_out, df_expect)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -953,11 +953,9 @@ class Test_ResultCollector:
         results.truncate(before="2020-01-01 01:00", after="2020-01-01 03:00")
         df_out = results.dataframe
         df_expect = pd.DataFrame(
-            data={
-            },
+            data={},
             index=pd.DatetimeIndex(
-                [
-                ],
+                [],
                 tz="utc",
             ),
         ).astype({"a": "float64", "b": "string", "c": "Int64", "d": "float64"})

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest-cov
 
 [testenv:docs]
-basepython = python3.11
+basepython = python3.12
 commands = sphinx-build -W -b html -d {toxworkdir}/docs_doctree docs {toxworkdir}/docs_out
 deps =
     sphinx == 5.3.0


### PR DESCRIPTION
### This PR is related to user story [ESS-3423](https://4insight.atlassian.net/browse/ESS-3423) and [ESS-3412](https://4insight.atlassian.net/browse/ESS-3412]) 
  [ESS-3435](https://4insight.atlassian.net/browse/ESS-3435]) 

## Description
Upgrade to support Python 3.11 to 3.13.

Make truncate safe on empty dataframes in ResultCollector (this was introduced with Pandas 2), where truncate on empty dataframes would give type errors.

Addressing empty checks for conact of arrays internally to remove future warnings 
https://github.com/4Subsea/fourinsight-engineroom-utils-python/issues/56

[ESS-3423]: https://4insight.atlassian.net/browse/ESS-3423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESS-3412]: https://4insight.atlassian.net/browse/ESS-3412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESS-3435]: https://4insight.atlassian.net/browse/ESS-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ