### PR TITLE
Add from_container_url class method to AzureBlobHandler

### DIFF
--- a/docs/user_guide/concepts_utils/handlers.rst
+++ b/docs/user_guide/concepts_utils/handlers.rst
@@ -26,7 +26,7 @@ The :class:`~fourinsight.engineroom.utils.AzureBlobHandler` is used to store tex
     from fourinsight.engineroom.utils import AzureBlobHandler
 
 
-     # Instantiate from a connection string
+    # Instantiate from a connection string
     handler = AzureBlobHandler(conn_str, container_name, blob_name)
 
     # Instantiate from a container-level SAS URL

--- a/docs/user_guide/concepts_utils/handlers.rst
+++ b/docs/user_guide/concepts_utils/handlers.rst
@@ -26,7 +26,11 @@ The :class:`~fourinsight.engineroom.utils.AzureBlobHandler` is used to store tex
     from fourinsight.engineroom.utils import AzureBlobHandler
 
 
-    handler = AzureBlobHandler(<connection-string>, <container-name>, <blob-name>)
+     # Instantiate from a connection string
+    handler = AzureBlobHandler(conn_str, container_name, blob_name)
+
+    # Instantiate from a container-level SAS URL
+    handler = AzureBlobHandler.from_container_url(container_url, blob_name)
 
 The handlers behave like 'streams', and provide all the normal stream capabilities. Downloading and uploading is done  by a push/pull
 strategy; content is retrieved from the source by a :meth:`~fourinsight.engineroom.utils.BaseHandler.pull()` request, and uploaded

--- a/fourinsight/engineroom/utils/_core.py
+++ b/fourinsight/engineroom/utils/_core.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 from azure.core.exceptions import ResourceNotFoundError
-from azure.storage.blob import BlobClient
+from azure.storage.blob import BlobClient, ContainerClient
 
 from ._constants import API_BASE_URL
 
@@ -188,8 +188,37 @@ class AzureBlobHandler(BaseHandler):
         )
         super().__init__(encoding=encoding, newline=newline)
 
+    @classmethod
+    def from_container_url(
+        cls, container_url, blob_name, encoding="utf-8", newline="\n"
+    ):
+        """
+        Instantiate from a container-level SAS URL.
+
+        Parameters
+        ----------
+        container_url : str
+            Full SAS URL for the container, e.g.
+            ``"https://<account>.blob.core.windows.net/<container>?sv=...&sig=..."``.
+        blob_name : str
+            The name of the blob with which to interact.
+        encoding : str
+            Defaults to 'utf-8'.
+        newline : str
+            Defaults to '\\n'.
+        """
+
+        instance = cls.__new__(cls)
+        instance._blob_client = ContainerClient.from_container_url(
+            container_url
+        ).get_blob_client(blob_name)
+        instance._blob_name = blob_name
+        BaseHandler.__init__(instance, encoding=encoding, newline=newline)
+        return instance
+
     def __repr__(self):
-        return f"AzureBlobHandler {self._container_name}/{self._blob_name}"
+        # return f"AzureBlobHandler {self._container_name}/{self._blob_name}"
+        return f"AzureBlobHandler {self._blob_client.container_name}/{self._blob_client.blob_name}"
 
     def _pull(self):
         return self._blob_client.download_blob().readinto(self.buffer)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,6 +52,9 @@ def azure_blob_handler_mocked(mock_from_connection_string):
     blob_name = "some_blob_name"
     handler = AzureBlobHandler(connection_string, container_name, blob_name)
 
+    handler._blob_client.container_name = "some_container_name"
+    handler._blob_client.blob_name = "some_blob_name"
+
     remote_content = open(REMOTE_FILE_PATH, mode="r").read()
     handler._blob_client.download_blob.return_value.readinto.side_effect = (
         lambda buffer: handler.write(remote_content)
@@ -270,6 +273,34 @@ class Test_AzureBlobHandler:
         handler._blob_client.upload_blob.assert_called_once_with(
             content, overwrite=True
         )
+
+    @patch("fourinsight.engineroom.utils._core.ContainerClient")
+    def test_blob_client_is_constructed_from_url(self, mock_container_client_cls):
+        AzureBlobHandler.from_container_url("some container", "state/state.json")
+        mock_container_client_cls.from_container_url.assert_called_once_with(
+            "some container"
+        )
+
+    @patch("fourinsight.engineroom.utils._core.ContainerClient")
+    def test_blob_client_gets_correct_blob(self, mock_container_client_cls):
+        AzureBlobHandler.from_container_url("some container", "state/state.json")
+        mock_container_client_cls.from_container_url().get_blob_client.assert_called_once_with(
+            "state/state.json"
+        )
+
+    @patch("fourinsight.engineroom.utils._core.ContainerClient")
+    def test_repr(self, mock_container_client_cls):
+        mock_blob_client = MagicMock()
+        mock_blob_client.container_name = "my-project"
+        mock_blob_client.blob_name = "state/state.json"
+        mock_container_client_cls.from_container_url().get_blob_client.return_value = (
+            mock_blob_client
+        )
+
+        handler = AzureBlobHandler.from_container_url(
+            "some container", "state/state.json"
+        )
+        assert repr(handler) == "AzureBlobHandler my-project/state/state.json"
 
 
 class Test_PersistentDict:


### PR DESCRIPTION
Adds a `from_container_url` class method to `AzureBlobHandler` that allows instantiation from a container-level SAS URL instead of a connection string.

The existing constructor requires an account-level connection string, which grants broad access to the storage account. A container-level SAS URL scopes access to a single container, which is preferable for security-sensitive use cases where access should be limited to a specific project.